### PR TITLE
Drop WT leak from "_wt" rows in parse_stripped_hgvs

### DIFF
--- a/tests/r/testthat/helper-functions.R
+++ b/tests/r/testthat/helper-functions.R
@@ -25,8 +25,6 @@ parse_stripped_hgvs <- function(hgvs_string) {
   mutation_type <- ""
   WT <- ""
 
-  WT <- substr(hgvs_string, 1, 1)
-
   # WT case, as in enrich2 format
   if (hgvs_string == "_wt") {
     variant <- "WT"

--- a/tests/r/testthat/test-parse_hgvs.R
+++ b/tests/r/testthat/test-parse_hgvs.R
@@ -119,6 +119,10 @@ test_that("parse_stripped_hgvs handles WT case", {
   expect_equal(result["variant"], c(variant = "WT"))
   expect_equal(result["pos"], c(pos = "0"))
   expect_equal(result["mutation_type"], c(mutation_type = "X"))
+  # Wildtype rows have no wildtype amino acid; assert explicitly because
+  # a regression where WT leaks "_" from the "_wt" sentinel is silent
+  # downstream (just produces nonsense in variant metadata).
+  expect_equal(result["WT"], c(WT = ""))
 })
 
 # =============================================================================

--- a/workflow/rules/scripts/run_rosace.R
+++ b/workflow/rules/scripts/run_rosace.R
@@ -59,8 +59,6 @@ parse_stripped_hgvs <- function(hgvs_string) {
   mutation_type <- ""
   WT <- ""
 
-  WT <- substr(hgvs_string, 1, 1)
-
   # WT case, as in enrich2 format
   if (hgvs_string == "_wt") {
     variant <- "WT"


### PR DESCRIPTION
run_rosace.R:62 (and the mirrored helper at tests/r/testthat/ helper-functions.R:28) ran:

  WT <- substr(hgvs_string, 1, 1)

ABOVE the "_wt" short-circuit. For wildtype rows this set WT to "_" before the function returned, leaving variant metadata with WT = "_" (the underscore from the sentinel string, not an amino acid). finalize_variants_in_rosace then propagated that into rosace_obj@var.data$wildtype, where it sat alongside real amino acid codes like "A", "M", etc.

Every downstream regex branch (synonymous, missense, nonsense, deletion, insertion) sets WT from its own str_match capture group, so the pre-branch substr() was a redundant initial guess that got overwritten in every successful parse. Removing it makes _wt return with WT = "" (matches the function's default initializer above), which finalize_variants_in_rosace happily passes through.

Side effect for malformed inputs that match no regex branch: WT changes from substr(hgvs, 1, 1) to "". The malformed-return case already has variant="", pos=-1, len=-1, mutation_type="" — adding WT="" to that list is more honest about "we couldn't parse this" than echoing back a stray first character.

Tighten the existing _wt test to assert WT = "" explicitly. The old test asserted variant/pos/mutation_type but skipped WT, which is how this lived for so long.