### PR TITLE
Add lilace to dumpling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "dumpling (canonical)",
+  "image": "mcr.microsoft.com/devcontainers/miniconda:1-3",
+  "remoteUser": "vscode",
+  "features": {},
+  "postCreateCommand": "conda env create -f dumpling_env.yaml || conda env update -f dumpling_env.yaml",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "REditorSupport.r",
+        "snakemake.snakemake-lang",
+        "redhat.vscode-yaml",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/conda/envs/dumpling_env/bin/python",
+        "r.useRenvLibPath": true,
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,24 @@
   "name": "dumpling (canonical)",
   "image": "mcr.microsoft.com/devcontainers/miniconda:1-3",
   "remoteUser": "vscode",
-  "features": {},
-  "postCreateCommand": "conda env create -f dumpling_env.yaml || conda env update -f dumpling_env.yaml",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": "gfortran,cmake,libuv1-dev,libxml2-dev,libcurl4-openssl-dev,libssl-dev,libnlopt-dev,libfontconfig1-dev,libharfbuzz-dev,libfribidi-dev,libtiff-dev,libjpeg-dev,libpng-dev"
+    },
+    "ghcr.io/rocker-org/devcontainer-features/r-apt:0": {
+      "version": "release",
+      "installRenv": true,
+      "installRMarkdown": false,
+      "installRadian": false,
+      "installVscDebugger": false,
+      "installBspm": false,
+      "vscodeRSupport": "minimal"
+    }
+  },
+  "containerEnv": {
+    "RENV_CONFIG_AUTOLOADER_ENABLED": "FALSE"
+  },
+  "postCreateCommand": "(conda env create -f dumpling_env.yaml || conda env update -f dumpling_env.yaml) && Rscript -e 'install.packages(c(\"dplyr\", \"readr\", \"stringr\", \"testthat\", \"withr\"), repos=\"https://cloud.r-project.org\")'",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and [Coyote-Maestas](https://www.wcoyotelab.com/) labs.
 Briefly, this conducts initial QC and mapping using BBTools, followed by the
 AnalyzeSaturationMutagenesis GATK module to call variants in each replicate. After variant calling, the list of observed variants in each read is filtered
 based on the list of designed variants, and the resulting counts are used to
-infer the fitness of each variant using [Rosace](https://github.com/pimentellab/rosace)
+infer the fitness of each variant using [Rosace](https://github.com/pimentellab/rosace), [Lilace](https://github.com/pimentellab/lilace),
 and (optionally) [Enrich2](https://github.com/FowlerLab/Enrich2).
 
 The pipeline is designed to be flexible and modular and should be amenable to use
@@ -18,8 +18,8 @@ with a variety of experimental designs. Please note several current [limitations
     - [Testing the pipeline with example data](#testing-the-pipeline-with-example-data)
   - [Installation](#installation)
     - [Install via GitHub](#install-via-github)
-    - [Installing Rosace](#installing-rosace)
-      - [Issues installing Rosace on OSX](#issues-installing-rosace-on-osx)
+    - [Installing Rosace and Lilace](#installing-rosace-and-lilace)
+      - [Issues installing Rosace and Lilace on OSX](#issues-installing-rosace-and-lilace-on-osx)
     - [Dependencies](#dependencies)
       - [Via conda (recommended)](#via-conda-recommended)
       - [Manually](#manually)
@@ -82,29 +82,33 @@ be used to compare results.
 
 Download or fork this repository and edit the configuration files as needed.
 
-### Installing Rosace
+### Installing Rosace and Lilace
 
-This pipeline uses the [Rosace](https://github.com/pimentellab/rosace) scoring tool.
-Rosace uses [CmdStanR](https://mc-stan.org/cmdstanr/) and R to infer scores.
+This pipeline supports the [Rosace](https://github.com/pimentellab/rosace) and [Lilace](https://github.com/pimentellab/lilace) scoring tools.
+Rosace and Lilace use [CmdStanR](https://mc-stan.org/cmdstanr/) and R to infer scores.
 
 Dumpling uses [renv](https://rstudio.github.io/renv/index.html) to handle R dependencies.
-This pipeline also includes a minimal faculty to install Rosace automatically, but issues are
+This pipeline also includes a minimal faculty to install Rosace and Lilace automatically, but issues are
 possible. This can be invoked by calling the `install_rosace` rule:
 
 ```snakemake --cores 8 install_rosace```
 
-This tries to install renv, restore the renv environment, and install Rosace and CmdStanR. If this fails,
-please try installing Rosace manually.
+or the `install_lilace` rule:
 
-We recommend installing Rosace manually before running the pipeline, or at least
-verifying that the install script works. More details about manually installing Rosace are
+```snakemake --cores 8 install_lilace```
+
+These try to install renv, restore the renv environment, and install Rosace or Lilace with CmdStanR. If this fails,
+please try installing them manually.
+
+We recommend trying to install either package manually before running the pipeline, or at least
+verifying that the install script works. More details about manually installing Rosace and Lilace are
 available in the vignettes of the package and at the repository linked above.
 
-#### Issues installing Rosace on OSX
+#### Issues installing Rosace and Lilace on OSX
 
-Rosace requires a C++ and fortran compiler to install required dependencies.
+Rosace and Lilace require a C++ and fortran compiler to install required dependencies.
 R, by default, requires these to be installed in `/opt/gfortran`. User installs (via Homebrew, for example)
-may not work. If you encounter an error compiling packages for Rosace, you may need to install the gfortran compiler from R.
+may not work. If you encounter an error compiling packages for Rosace or Lilace, you may need to install the gfortran compiler from R.
 
 See https://cran.r-project.org/bin/macosx/tools/ for more details.
 
@@ -136,6 +140,7 @@ The following are the dependencies required to run the pipeline:
 - [MultiQC](http://multiqc.info/)
 - [Enrich2](https://enrich2.readthedocs.io/en/latest/)
 - [Rosace](https://github.com/pimentellab/rosace)
+- [Lilace](https://github.com/pimentellab/lilace)
 
 BBTools compressed IO defaults to `bgzip` in this pipeline. If your environment hangs in
 `bbduk.sh`, `bbmerge.sh`, or `bbmap.sh`, set `bbtools_use_bgzip: false` in the config to
@@ -267,16 +272,19 @@ its functionality. However, there are currently several known limitations.
 - The pipeline is currently designed for direct sequencing. It does not support barcoded sequencing.
 - The pipeline is currently designed for single-site variants (including varying-length indels, however). It largely does not support combinatorial variants.
 - The designed variant generation step is currently optimized for DIMPLE libraries. Other protocols may require the user to generate the designed variants CSV themself.
-- Rosace is designed for growth-based experiments. It is not optimized for FACS-seq experiments.
 - This pipeline may not work properly if the data is in a cloud server (i.e., a Box drive) or other non-standard file system.
 - This pipeline currently only accepts fastq.gz files. It does not accept fastq files.
 
 ## Citations
 
-This workflow is described in the following publication:
+This workflow, along with Rosace, is described in the following publication:
 
 - Preprint: [Rao et al., 2023](https://www.biorxiv.org/content/10.1101/2023.10.24.562292v1)
 - Published: [Rao et al., 2024](https://doi.org/10.1186/s13059-024-03279-7)
+
+The Lilace FACS-based model is described in:
+
+- [Freudenberg et al., 2026](https://doi.org/10.1186/s13059-026-03934-1)
 
 ## License
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -67,8 +67,9 @@ oligo_file: "config/oligos/example_oligos.csv"
 # regenerate_variants: Regenerate the variants file from the oligo file. This is
 #                      only necessary if the variants file is not already present.
 #
-# #### Enrich2-specific parameters ####
-# enrich2: Set to true to run Enrich2 in addition to Rosace.
+# #### Scoring and Enrich2 parameters ####
+# scoring_backend: Variant scoring backend. Options: rosace (default) or lilace.
+# enrich2: Set to true to run Enrich2 in addition to backend scoring.
 # noprocess: Set to True to skip variant filtering based on designed variants.
 # run_qc: Set to False to skip QC steps (fastqc and multiqc)
 #
@@ -82,6 +83,7 @@ oligo_file: "config/oligos/example_oligos.csv"
 #                      Defaults to 3.
 # -----------------------------------------------------------------------------
 orf: "141-1568"
+scoring_backend: rosace
 enrich2: true
 remove_zeros: true
 regenerate_variants: false
@@ -105,6 +107,8 @@ max_deletion_length: 3
 # samtools_local: Flag for whether to use a locally-installed samtools or the wrapper version.
 #                 This is useful for platforms (such as ARM Macs currently) where conda does
 #                 not have a compatible samtools version.
+# rosace_local: Use locally-managed Rosace/cmdstanr instead of renv+conda rule environment.
+# lilace_local: Use locally-managed Lilace/cmdstanr instead of renv+conda rule environment.
 # bbtools_use_bgzip: Keep BBTools on bgzip for compressed IO. Set to false only if
 #                    your environment hangs in BBTools and you need to fall back to pigz/unpigz.
 #
@@ -117,6 +121,7 @@ min_q: 30
 
 samtools_local: false
 rosace_local: false
+lilace_local: false
 bbtools_use_bgzip: true
 
 # -----------------------------------------------------------------------------

--- a/renv.lock
+++ b/renv.lock
@@ -2476,6 +2476,48 @@
       "Maintainer": "Lionel Henry <lionel@posit.co>",
       "Repository": "CRAN"
     },
+    "lilace": {
+      "Package": "lilace",
+      "Version": "1.0.0",
+      "Source": "GitHub",
+      "Title": "Analyze FACS-based Deep Mutational Scanning Data",
+      "Authors@R": "person(\"Jerome\", \"Freudenberg\", email = \"jfreudenberg@ucla.edu\", role = c(\"aut\", \"cre\"), comment=c(ORCID=\"0009-0004-7464-8333\"))",
+      "Description": "A Bayesian hierarchical model for estimating variant effect sizes and uncertainty from FACS-based DMS data.",
+      "License": "MIT + file LICENSE",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "Depends": [
+        "R (>= 3.6)"
+      ],
+      "Suggests": [
+        "knitr",
+        "rmarkdown",
+        "posterior"
+      ],
+      "Imports": [
+        "cmdstanr (>= 0.8.0)",
+        "cowplot",
+        "ggpubr",
+        "colorspace",
+        "dplyr",
+        "ggplot2",
+        "readr",
+        "stringr",
+        "tidyr",
+        "utils",
+        "yaml"
+      ],
+      "RoxygenNote": "7.3.2",
+      "VignetteBuilder": "knitr",
+      "Author": "Jerome Freudenberg [aut, cre] (ORCID: 0009-0004-7464-8333)",
+      "Maintainer": "Jerome Freudenberg <jfreudenberg@ucla.edu>",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "pimentellab",
+      "RemoteRepo": "lilace",
+      "RemoteRef": "main",
+      "RemoteSha": "9a4f6d371cc70e0741da3c88c2c36fc0a1eb46fe"
+    },
     "lme4": {
       "Package": "lme4",
       "Version": "2.0-1",
@@ -4652,6 +4694,25 @@
       "NeedsCompilation": "no",
       "Author": "Jim Hester [aut], Lionel Henry [aut, cre], Kirill Müller [aut], Kevin Ushey [aut], Hadley Wickham [aut], Winston Chang [aut], Jennifer Bryan [ctb], Richard Cotton [ctb], Posit Software, PBC [cph, fnd]",
       "Maintainer": "Lionel Henry <lionel@posit.co>",
+      "Repository": "CRAN"
+    },
+    "yaml": {
+      "Package": "yaml",
+      "Version": "2.3.10",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "Methods to Convert R Data to YAML and Back",
+      "Imports": [
+        "stats"
+      ],
+      "Description": "Implements the libyaml YAML 1.1 parser and emitter (https://pyyaml.org/wiki/LibYAML) for R.",
+      "License": "BSD_3_clause + file LICENSE",
+      "URL": "https://github.com/vubiostat/r-yaml/",
+      "BugReports": "https://github.com/vubiostat/r-yaml/issues",
+      "Encoding": "UTF-8",
+      "NeedsCompilation": "yes",
+      "Author": "Jeremy Stephens [aut, cre], Kirill Simonov [aut], Hadley Wickham [aut], others",
+      "Maintainer": "Shawn Garbett <shawn.garbett@vumc.org>",
       "Repository": "CRAN"
     },
     "zoo": {

--- a/renv.lock
+++ b/renv.lock
@@ -3339,7 +3339,7 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.8.6",
+      "Version": "3.9.0",
       "Source": "Repository",
       "Title": "Execute and Control System Processes",
       "Authors@R": "c( person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"), comment = c(ORCID = \"0000-0001-7098-9676\")), person(\"Winston\", \"Chang\", role = \"aut\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")), person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\")) )",

--- a/tests/integration/test_dag_construction.py
+++ b/tests/integration/test_dag_construction.py
@@ -137,7 +137,12 @@ contaminants:
 
     def test_dry_run_with_lilace_backend(self, repo_root, fixtures_dir, tmp_path):
         """Dry-run with scoring_backend=lilace should construct the DAG without crashing
-        and schedule lilace rules instead of rosace."""
+        and schedule lilace rules instead of rosace.
+
+        noprocess is deliberately false here — lilace requires a synonymous-variant
+        control set and validate_scoring_backend_mode rejects noprocess+lilace at
+        parse time. See test_noprocess_with_lilace_rejected for that path.
+        """
         test_dir = tmp_path / "test_run_lilace"
         test_dir.mkdir()
 
@@ -152,7 +157,7 @@ oligo_file: '{fixtures_dir / "mock_oligos.csv"}'
 orf: "1-300"
 scoring_backend: 'lilace'
 enrich2: false
-noprocess: true
+noprocess: false
 run_qc: false
 baseline_condition: 'baseline'
 remove_zeros: false
@@ -214,6 +219,72 @@ contaminants:
                 "Lilace backend selected but run_rosace was also scheduled:\n"
                 f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
             )
+
+    def test_noprocess_with_lilace_rejected(self, repo_root, fixtures_dir, tmp_path):
+        """noprocess + scoring_backend=lilace must error at parse time, not deep
+        inside R after install_lilace runs. validate_scoring_backend_mode is the
+        gate; this test exercises it through the actual Snakefile."""
+        test_dir = tmp_path / "test_run_noprocess_lilace"
+        test_dir.mkdir()
+
+        config_content = f"""
+experiment: 'test_experiment'
+data_dir: '{fixtures_dir}'
+ref_dir: '{fixtures_dir}'
+experiment_file: '{fixtures_dir / "mock_experiment.csv"}'
+reference: 'mock_reference.fasta'
+variants_file: '{fixtures_dir / "mock_variants.csv"}'
+oligo_file: '{fixtures_dir / "mock_oligos.csv"}'
+orf: "1-300"
+scoring_backend: 'lilace'
+enrich2: false
+noprocess: true
+run_qc: false
+baseline_condition: 'baseline'
+remove_zeros: false
+regenerate_variants: false
+kmers: 15
+sam: "1.3"
+mem: 4
+min_q: 30
+min_variant_obs: 3
+max_deletion_length: 3
+samtools_local: false
+rosace_local: false
+lilace_local: false
+adapters: 'resources/adapters.fa'
+contaminants:
+  - 'resources/sequencing_artifacts.fa.gz'
+"""
+        config_file = test_dir / "test_config.yaml"
+        config_file.write_text(config_content)
+
+        result = subprocess.run(
+            [
+                "snakemake",
+                "-s",
+                str(repo_root / "workflow" / "Snakefile"),
+                "--configfile",
+                str(config_file),
+                "--dry-run",
+                "--cores",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+
+        assert result.returncode != 0, (
+            "noprocess+lilace should be rejected at parse time, but Snakefile "
+            f"loaded cleanly.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "lilace" in combined.lower() and "noprocess" in combined.lower(), (
+            "Error message should mention both lilace and noprocess so the user "
+            f"knows the combination is the problem.\nSTDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
 
     def test_script_rule_executes_with_runtime_injection(
         self, repo_root, fixtures_dir, tmp_path

--- a/tests/integration/test_dag_construction.py
+++ b/tests/integration/test_dag_construction.py
@@ -47,6 +47,7 @@ class TestDAGConstruction:
             "process.smk",
             "qc.smk",
             "rosace.smk",
+            "lilace.smk",
             "enrich.smk",
         ]
 
@@ -133,6 +134,86 @@ contaminants:
             # Check if it's a missing file error (expected) vs syntax error (not expected)
             assert "SyntaxError" not in result.stderr, f"Syntax error: {result.stderr}"
             assert "NameError" not in result.stderr, f"Name error: {result.stderr}"
+
+    def test_dry_run_with_lilace_backend(self, repo_root, fixtures_dir, tmp_path):
+        """Dry-run with scoring_backend=lilace should construct the DAG without crashing
+        and schedule lilace rules instead of rosace."""
+        test_dir = tmp_path / "test_run_lilace"
+        test_dir.mkdir()
+
+        config_content = f"""
+experiment: 'test_experiment'
+data_dir: '{fixtures_dir}'
+ref_dir: '{fixtures_dir}'
+experiment_file: '{fixtures_dir / "mock_experiment.csv"}'
+reference: 'mock_reference.fasta'
+variants_file: '{fixtures_dir / "mock_variants.csv"}'
+oligo_file: '{fixtures_dir / "mock_oligos.csv"}'
+orf: "1-300"
+scoring_backend: 'lilace'
+enrich2: false
+noprocess: true
+run_qc: false
+baseline_condition: 'baseline'
+remove_zeros: false
+regenerate_variants: false
+kmers: 15
+sam: "1.3"
+mem: 4
+min_q: 30
+min_variant_obs: 3
+max_deletion_length: 3
+samtools_local: false
+rosace_local: false
+lilace_local: false
+adapters: 'resources/adapters.fa'
+contaminants:
+  - 'resources/sequencing_artifacts.fa.gz'
+"""
+        config_file = test_dir / "test_config.yaml"
+        config_file.write_text(config_content)
+
+        result = subprocess.run(
+            [
+                "snakemake",
+                "-s",
+                str(repo_root / "workflow" / "Snakefile"),
+                "--configfile",
+                str(config_file),
+                "--dry-run",
+                "-p",
+                "--cores",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+
+        # As with the rosace dry-run, fixtures are incomplete so a non-zero exit
+        # is acceptable — what we care about is that config parsing and rule
+        # construction succeed for the lilace path.
+        if result.returncode != 0:
+            assert "SyntaxError" not in result.stderr, f"Syntax error: {result.stderr}"
+            assert "NameError" not in result.stderr, f"Name error: {result.stderr}"
+            # KeyError on a config key (e.g. mem_lilace) means the setdefault /
+            # schema-default path is broken and would prevent any lilace run.
+            assert "KeyError" not in result.stderr, (
+                f"Missing config key in lilace path: {result.stderr}"
+            )
+
+        # If anything got printed at all, the DAG should mention lilace rather
+        # than rosace. Don't fail on empty output (missing-file errors abort early).
+        combined = result.stdout + result.stderr
+        if "rule " in combined:
+            assert "lilace" in combined.lower(), (
+                "Lilace backend selected but no lilace rule scheduled:\n"
+                f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
+            assert "run_rosace" not in combined, (
+                "Lilace backend selected but run_rosace was also scheduled:\n"
+                f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
 
     def test_script_rule_executes_with_runtime_injection(
         self, repo_root, fixtures_dir, tmp_path
@@ -252,3 +333,27 @@ class TestConditionalRules:
         # Check for rosace-related rules
         assert "rosace" in content.lower()
         assert "rule" in content
+
+    def test_lilace_rules_exist(self, repo_root):
+        """Test that lilace rules exist."""
+        lilace_file = repo_root / "workflow" / "rules" / "lilace.smk"
+        content = lilace_file.read_text()
+
+        assert "lilace" in content.lower()
+        assert "rule run_lilace" in content
+        assert "rule install_lilace" in content
+
+    def test_get_input_branches_on_scoring_backend(self, repo_root):
+        """get_input must interpolate the scoring_backend into its output targets,
+        so flipping config['scoring_backend'] actually switches the requested rules."""
+        common_smk = (repo_root / "workflow" / "rules" / "common.smk").read_text()
+
+        # The f-string forms used in get_input — these are the exact templates
+        # that drive backend selection. If they're refactored, this test should
+        # be updated deliberately, not silently broken.
+        assert "{scoring_backend}/{{conditions}}_scores.csv" in common_smk, (
+            "get_input no longer interpolates scoring_backend into the scores target"
+        )
+        assert "{scoring_backend}/{scoring_backend}_installed.txt" in common_smk, (
+            "get_input no longer interpolates scoring_backend into the install marker"
+        )

--- a/tests/r/testthat/helper-lilace-functions.R
+++ b/tests/r/testthat/helper-lilace-functions.R
@@ -1,0 +1,93 @@
+# helper-lilace-functions.R
+# Extracted pure function from workflow/rules/scripts/run_lilace.R for testing.
+#
+# Mirrors the pattern in helper-functions.R (Rosace): the source script
+# contains snakemake-only top-level code, so we maintain a parallel testable
+# copy here. Any change to parse_stripped_hgvs in run_lilace.R must be
+# reflected here, and vice versa.
+#
+# The Lilace parser differs from the Rosace one in return shape and
+# semantics: it returns a list with $position/$wildtype/$mutation/$type
+# (vs Rosace's named char vector), and it errors on unsupported formats
+# rather than returning sentinel empty values.
+
+suppressPackageStartupMessages({
+  library(stringr)
+})
+
+#' Parse a stripped HGVS variant string (Lilace flavor)
+#'
+#' @param hgvs_string HGVS protein string without the `p.(...)` wrapper,
+#'   or the literal `_wt` for wildtype rows.
+#' @return Named list with fields: position (numeric), wildtype (char),
+#'   mutation (char), type (one of "synonymous", "missense", "nonsense",
+#'   "deletion", "insertion").
+parse_stripped_hgvs_lilace <- function(hgvs_string) {
+  if (hgvs_string == "_wt") {
+    return(list(position = 0, wildtype = "", mutation = "WT", type = "synonymous"))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+=$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)=")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = match[2],
+      type = "synonymous"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+[A-Z]$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)([A-Z])")
+    mut_type <- ifelse(match[2] == match[4], "synonymous", "missense")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = match[4],
+      type = mut_type
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+\\*$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)\\*")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = "*",
+      type = "nonsense"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+_[A-Z][0-9]+del$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)_([A-Z])([0-9]+)del")
+    len <- as.integer(match[5]) - as.integer(match[3]) + 1
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = paste0("D_", len),
+      type = "deletion"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+del$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)del")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = "D_1",
+      type = "deletion"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+_[A-Z][0-9]+ins[A-Z]+$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)_([A-Z])([0-9]+)ins([A-Z]+)")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = paste0("I_", nchar(match[6])),
+      type = "insertion"
+    ))
+  }
+
+  stop(sprintf("Unsupported HGVS format encountered: %s", hgvs_string))
+}

--- a/tests/r/testthat/test-parse_hgvs_lilace.R
+++ b/tests/r/testthat/test-parse_hgvs_lilace.R
@@ -1,0 +1,128 @@
+# test-parse_hgvs_lilace.R
+# Unit tests for the Lilace-flavored HGVS parser
+# (parse_stripped_hgvs_lilace, defined in helper-lilace-functions.R).
+
+library(testthat)
+
+context("HGVS Parsing (Lilace)")
+
+# -----------------------------------------------------------------------------
+# Happy-path: one test per supported HGVS shape.
+# -----------------------------------------------------------------------------
+
+test_that("parse_stripped_hgvs_lilace handles wildtype (_wt)", {
+  result <- parse_stripped_hgvs_lilace("_wt")
+  expect_equal(result$position, 0)
+  expect_equal(result$wildtype, "")
+  expect_equal(result$mutation, "WT")
+  expect_equal(result$type, "synonymous")
+})
+
+test_that("parse_stripped_hgvs_lilace handles HGVS-style synonymous (X1=)", {
+  result <- parse_stripped_hgvs_lilace("A123=")
+  expect_equal(result$position, 123)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "A")
+  expect_equal(result$type, "synonymous")
+})
+
+test_that("parse_stripped_hgvs_lilace handles GATK/dimple-style synonymous (X1X)", {
+  result <- parse_stripped_hgvs_lilace("A123A")
+  expect_equal(result$position, 123)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "A")
+  expect_equal(result$type, "synonymous")
+})
+
+test_that("parse_stripped_hgvs_lilace handles missense (X1Y)", {
+  result <- parse_stripped_hgvs_lilace("A123T")
+  expect_equal(result$position, 123)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "T")
+  expect_equal(result$type, "missense")
+})
+
+test_that("parse_stripped_hgvs_lilace handles nonsense (X1*)", {
+  result <- parse_stripped_hgvs_lilace("W42*")
+  expect_equal(result$position, 42)
+  expect_equal(result$wildtype, "W")
+  expect_equal(result$mutation, "*")
+  expect_equal(result$type, "nonsense")
+})
+
+test_that("parse_stripped_hgvs_lilace handles single-codon deletion (X1del)", {
+  result <- parse_stripped_hgvs_lilace("A10del")
+  expect_equal(result$position, 10)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "D_1")
+  expect_equal(result$type, "deletion")
+})
+
+test_that("parse_stripped_hgvs_lilace handles multi-codon deletion (X1_Xn del)", {
+  result <- parse_stripped_hgvs_lilace("A10_C12del")
+  expect_equal(result$position, 10)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "D_3")
+  expect_equal(result$type, "deletion")
+})
+
+test_that("parse_stripped_hgvs_lilace handles single-AA insertion", {
+  result <- parse_stripped_hgvs_lilace("A10_C11insG")
+  expect_equal(result$position, 10)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "I_1")
+  expect_equal(result$type, "insertion")
+})
+
+test_that("parse_stripped_hgvs_lilace handles multi-AA insertion", {
+  result <- parse_stripped_hgvs_lilace("A10_C11insGGS")
+  expect_equal(result$position, 10)
+  expect_equal(result$wildtype, "A")
+  expect_equal(result$mutation, "I_3")
+  expect_equal(result$type, "insertion")
+})
+
+# -----------------------------------------------------------------------------
+# Position / amino acid coverage: each supported AA is parsed correctly,
+# and large position numbers don't truncate.
+# -----------------------------------------------------------------------------
+
+test_that("parse_stripped_hgvs_lilace extracts WT for all 20 standard amino acids", {
+  amino_acids <- c(
+    "A", "C", "D", "E", "F", "G", "H", "I", "K", "L",
+    "M", "N", "P", "Q", "R", "S", "T", "V", "W", "Y"
+  )
+  for (aa in amino_acids) {
+    result <- parse_stripped_hgvs_lilace(paste0(aa, "1="))
+    expect_equal(result$wildtype, aa, info = paste("Failed for amino acid:", aa))
+  }
+})
+
+test_that("parse_stripped_hgvs_lilace preserves large position numbers", {
+  result <- parse_stripped_hgvs_lilace("A9999T")
+  expect_equal(result$position, 9999)
+  expect_equal(result$type, "missense")
+})
+
+# -----------------------------------------------------------------------------
+# Negative path: unsupported formats should error loudly with the input
+# echoed back, not return a silently-wrong record.
+# -----------------------------------------------------------------------------
+
+test_that("parse_stripped_hgvs_lilace errors on unsupported format", {
+  expect_error(
+    parse_stripped_hgvs_lilace("not-a-variant"),
+    "Unsupported HGVS format"
+  )
+})
+
+test_that("parse_stripped_hgvs_lilace error message includes the offending input", {
+  expect_error(
+    parse_stripped_hgvs_lilace("weird-input-xyz"),
+    "weird-input-xyz"
+  )
+})
+
+test_that("parse_stripped_hgvs_lilace rejects empty string", {
+  expect_error(parse_stripped_hgvs_lilace(""))
+})

--- a/tests/unit/test_scoring_backend_config.py
+++ b/tests/unit/test_scoring_backend_config.py
@@ -62,6 +62,13 @@ class TestSchemaShape:
         assert prop["type"] == "integer"
         assert prop["default"] == 16000
 
+    def test_lilace_local_property_present(self):
+        schema = _load_schema()
+        assert "lilace_local" in schema["properties"]
+        prop = schema["properties"]["lilace_local"]
+        assert prop["type"] == "boolean"
+        assert prop["default"] is False
+
 
 # -----------------------------------------------------------------------------
 # Plain jsonschema validation: enum enforcement, type checks. No default
@@ -130,3 +137,9 @@ class TestDefaultInjection:
         assert "mem_lilace" not in config
         self.snakemake_validate(config, str(SCHEMA_PATH))
         assert config.get("mem_lilace") == 16000
+
+    def test_lilace_local_default_is_false(self):
+        config = _minimal_valid_config()
+        assert "lilace_local" not in config
+        self.snakemake_validate(config, str(SCHEMA_PATH))
+        assert config.get("lilace_local") is False

--- a/tests/unit/test_scoring_backend_config.py
+++ b/tests/unit/test_scoring_backend_config.py
@@ -1,0 +1,132 @@
+"""
+Schema-level tests for the scoring_backend / lilace_local / mem_lilace
+configuration knobs introduced for the Lilace scoring backend.
+
+These tests cover the config.schema.yaml contract and the
+snakemake-utils-validate default-injection behavior. They are gated on
+the availability of snakemake (for default injection) or jsonschema (for
+plain validation), and skip cleanly when neither is installed.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "workflow" / "schemas" / "config.schema.yaml"
+
+
+def _load_schema():
+    with open(SCHEMA_PATH) as fh:
+        return yaml.safe_load(fh)
+
+
+def _minimal_valid_config():
+    """A config that satisfies all `required` fields in config.schema.yaml.
+
+    Intentionally omits all optional fields so the tests can observe whether
+    defaults are filled or whether enums are enforced.
+    """
+    return {
+        "data_dir": "example/data",
+        "experiment": "test_experiment",
+        "experiment_file": "config/example.csv",
+        "ref_dir": "references",
+        "reference": "example_ref.fasta",
+        "orf": "1-300",
+        "adapters": "resources/adapters.fa",
+        "contaminants": ["resources/sequencing_artifacts.fa.gz"],
+    }
+
+
+# -----------------------------------------------------------------------------
+# Schema shape: enums and properties are present in the document on disk.
+# These run with no extra deps and catch the most common drift.
+# -----------------------------------------------------------------------------
+
+
+class TestSchemaShape:
+    def test_scoring_backend_property_present(self):
+        schema = _load_schema()
+        assert "scoring_backend" in schema["properties"]
+        prop = schema["properties"]["scoring_backend"]
+        assert prop["type"] == "string"
+        assert set(prop["enum"]) == {"rosace", "lilace"}
+        assert prop["default"] == "rosace"
+
+    def test_mem_lilace_property_present(self):
+        schema = _load_schema()
+        assert "mem_lilace" in schema["properties"]
+        prop = schema["properties"]["mem_lilace"]
+        assert prop["type"] == "integer"
+        assert prop["default"] == 16000
+
+
+# -----------------------------------------------------------------------------
+# Plain jsonschema validation: enum enforcement, type checks. No default
+# injection (jsonschema doesn't fill defaults by default).
+# -----------------------------------------------------------------------------
+
+
+jsonschema = pytest.importorskip(
+    "jsonschema",
+    reason="jsonschema not installed; skipping schema enum tests",
+)
+
+
+class TestEnumEnforcement:
+    def test_scoring_backend_rosace_accepted(self):
+        config = _minimal_valid_config()
+        config["scoring_backend"] = "rosace"
+        jsonschema.validate(config, _load_schema())
+
+    def test_scoring_backend_lilace_accepted(self):
+        config = _minimal_valid_config()
+        config["scoring_backend"] = "lilace"
+        jsonschema.validate(config, _load_schema())
+
+    def test_scoring_backend_unknown_rejected(self):
+        config = _minimal_valid_config()
+        config["scoring_backend"] = "enrich2"
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(config, _load_schema())
+        # Error message should reference the offending value or the enum.
+        msg = str(excinfo.value)
+        assert "enrich2" in msg or "enum" in msg
+
+    def test_scoring_backend_omitted_validates(self):
+        """Omitting scoring_backend is fine — it has a default and is not required."""
+        config = _minimal_valid_config()
+        config.pop("scoring_backend", None)
+        jsonschema.validate(config, _load_schema())
+
+
+# -----------------------------------------------------------------------------
+# Default injection via snakemake.utils.validate. This is the behavior
+# common.smk actually relies on, so worth covering even though it requires
+# snakemake to be importable.
+# -----------------------------------------------------------------------------
+
+
+class TestDefaultInjection:
+    """Verify snakemake.utils.validate fills in schema defaults."""
+
+    @pytest.fixture(autouse=True)
+    def _require_snakemake(self):
+        self.snakemake_validate = pytest.importorskip(
+            "snakemake.utils",
+            reason="snakemake not installed; skipping default-injection tests",
+        ).validate
+
+    def test_scoring_backend_default_is_rosace(self):
+        config = _minimal_valid_config()
+        assert "scoring_backend" not in config
+        self.snakemake_validate(config, str(SCHEMA_PATH))
+        assert config.get("scoring_backend") == "rosace"
+
+    def test_mem_lilace_default_is_16000(self):
+        config = _minimal_valid_config()
+        assert "mem_lilace" not in config
+        self.snakemake_validate(config, str(SCHEMA_PATH))
+        assert config.get("mem_lilace") == 16000

--- a/tests/unit/test_script_utils.py
+++ b/tests/unit/test_script_utils.py
@@ -8,6 +8,7 @@ from workflow.rules.scripts.script_utils import (
     run_script,
     translate_orf,
     validate_experiment_time_or_bin,
+    validate_scoring_backend_mode,
 )
 
 
@@ -220,3 +221,31 @@ class TestValidateExperimentTimeOrBin:
         assert "'bad1'" in msg
         assert "'bad2'" in msg
         assert "'ok'" not in msg
+
+
+class TestValidateScoringBackendMode:
+    """Lilace's Stan model requires a synonymous control set and has no
+    total-counts fallback. noprocess mode doesn't produce trustworthy
+    synonymous labels, so the combination must be rejected at parse time."""
+
+    def test_lilace_with_noprocess_rejected(self):
+        config = {"scoring_backend": "lilace", "noprocess": True}
+        with pytest.raises(ValueError, match="lilace.*incompatible.*noprocess"):
+            validate_scoring_backend_mode(config)
+
+    def test_lilace_without_noprocess_passes(self):
+        config = {"scoring_backend": "lilace", "noprocess": False}
+        validate_scoring_backend_mode(config)
+
+    def test_rosace_with_noprocess_passes(self):
+        config = {"scoring_backend": "rosace", "noprocess": True}
+        validate_scoring_backend_mode(config)
+
+    def test_rosace_without_noprocess_passes(self):
+        config = {"scoring_backend": "rosace", "noprocess": False}
+        validate_scoring_backend_mode(config)
+
+    def test_missing_keys_treated_as_falsy(self):
+        """Defaults aren't this function's job — schema validation fills
+        them in. An empty config shouldn't crash here."""
+        validate_scoring_backend_mode({})

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,6 +19,7 @@ include: "rules/baseline_qc.smk"
 include: "rules/qc.smk"
 include: "rules/ref.smk"
 include: "rules/rosace.smk"
+include: "rules/lilace.smk"
 
 
 # Pseudo-rule for running analysis

--- a/workflow/envs/lilace.yaml
+++ b/workflow/envs/lilace.yaml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - r-base
+  - r-nloptr
+  - nlopt
+  - libxml2
+  # cmake must be <3.25 for CmdStan compatibility.
+  - cmake <3.25
+  - zlib

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -94,12 +94,12 @@ def get_input(wildcards):
     if experiment_samples:
         input_list.extend(
             expand(
-                "results/{experiment_name}/rosace/{conditions}_scores.csv",
+                f"results/{{experiment_name}}/{scoring_backend}/{{conditions}}_scores.csv",
                 experiment_name=config["experiment"],
                 conditions=experimental_conditions,
             )
             + expand(
-                "results/{experiment_name}/rosace/rosace_installed.txt",
+                f"results/{{experiment_name}}/{scoring_backend}/{scoring_backend}_installed.txt",
                 experiment_name=config["experiment"],
             ),
         )
@@ -198,6 +198,8 @@ def validate_config(config):
 
 # Validate config and experiment files
 config.setdefault("bbtools_use_bgzip", True)
+config.setdefault("scoring_backend", "rosace")
+config.setdefault("lilace_local", False)
 validate(config, "../schemas/config.schema.yaml")
 
 experiments = load_experiments(config["experiment_file"])
@@ -212,7 +214,8 @@ baseline_samples, baseline_files = get_baseline_samples(experiments, samples)
 experiment_samples = get_experiment_samples(experiments, samples)
 files = experiments["file"]
 conditions = set(experiments["condition"])
-experimental_conditions = conditions - set([config["baseline_condition"]])
+experimental_conditions = sorted(conditions - set([config["baseline_condition"]]))
+scoring_backend = config["scoring_backend"]
 
 
 # Load additional files

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -200,6 +200,7 @@ def validate_config(config):
 config.setdefault("bbtools_use_bgzip", True)
 config.setdefault("scoring_backend", "rosace")
 config.setdefault("lilace_local", False)
+config.setdefault("mem_lilace", 16000)
 validate(config, "../schemas/config.schema.yaml")
 
 experiments = load_experiments(config["experiment_file"])

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -13,6 +13,7 @@ from script_utils import (  # noqa: E402
     load_experiments,
     resolve_fastq_pair,
     validate_experiment_time_or_bin,
+    validate_scoring_backend_mode,
 )
 
 
@@ -202,6 +203,7 @@ config.setdefault("scoring_backend", "rosace")
 config.setdefault("lilace_local", False)
 config.setdefault("mem_lilace", 16000)
 validate(config, "../schemas/config.schema.yaml")
+validate_scoring_backend_mode(config)
 
 experiments = load_experiments(config["experiment_file"])
 

--- a/workflow/rules/lilace.smk
+++ b/workflow/rules/lilace.smk
@@ -1,0 +1,36 @@
+rule run_lilace:
+    input:
+        expand(
+            "results/{{experiment_name}}/processed_counts/enrich_format/{experiments}.tsv",
+            experiments=experiment_samples,
+        ),
+        "results/{experiment_name}/lilace/lilace_installed.txt",
+    output:
+        expand(
+            "results/{{experiment_name}}/lilace/{conditions}_scores.csv",
+            conditions=experimental_conditions,
+        ),
+    benchmark:
+        "benchmarks/{experiment_name}/{experiment_name}.lilace.benchmark.txt"
+    log:
+        "logs/{experiment_name}/lilace/{experiment_name}.lilace.log",
+    threads: 4
+    resources:
+        mem_mb=config["mem_lilace"],
+    conda:
+        "../envs/lilace.yaml" if not config["lilace_local"] else None
+    script:
+        "scripts/run_lilace.R"
+
+
+rule install_lilace:
+    output:
+        "results/{experiment_name}/lilace/lilace_installed.txt",
+    benchmark:
+        "benchmarks/{experiment_name}/install_lilace.benchmark.txt"
+    log:
+        "logs/{experiment_name}/install_lilace.log",
+    conda:
+        "../envs/lilace.yaml" if not config["lilace_local"] else None
+    script:
+        "scripts/install_lilace.R"

--- a/workflow/rules/scripts/install_lilace.R
+++ b/workflow/rules/scripts/install_lilace.R
@@ -1,0 +1,87 @@
+# Set up logging
+log_file <- snakemake@log[[1]]
+output_file <- snakemake@output[[1]]
+
+con <- file(log_file, open = "wt")
+sink(con, append = FALSE, split = FALSE, type = "message")
+sink(con, append = FALSE, split = FALSE, type = "output")
+
+log_and_rethrow <- function(script_name, err) {
+  message(sprintf("%s failed: %s", script_name, conditionMessage(err)))
+  calls <- vapply(
+    sys.calls(),
+    function(call) paste(deparse(call), collapse = " "),
+    character(1)
+  )
+  if (length(calls) > 0) {
+    message("Call stack:")
+    message(paste(calls, collapse = "\n"))
+  }
+  stop(err)
+}
+
+main <- function() {
+  if (snakemake@config[["lilace_local"]]) {
+    message("Checking local R environment for Lilace.")
+
+    if (!require(cmdstanr)) {
+      stop("cmdstanr not installed. Please check installation.")
+    }
+    message("Local cmdstanr found.")
+
+    tryCatch(
+      {
+        install_cmdstan(overwrite = FALSE)
+      },
+      warning = function(w) {
+        message("cmdstan already installed. Not reinstalling.")
+      }
+    )
+
+    if (!require(lilace)) {
+      stop("Lilace not available in local R environment. Please check installation.")
+    }
+    message("Local lilace found.")
+  } else {
+    install.packages("renv", repos = c("https://cloud.r-project.org"))
+
+    library("renv")
+    renv::restore()
+
+    library("cmdstanr")
+
+    tryCatch(
+      check_cmdstan_toolchain(),
+      error = function(e) {
+        stop(paste(
+          "CmdStan toolchain check failed. Ensure a C++ compiler (gcc/clang) and",
+          "cmake <3.25 are available in the conda environment.\nOriginal error:", conditionMessage(e)
+        ))
+      }
+    )
+
+    tryCatch(
+      {
+        install_cmdstan(overwrite = FALSE)
+      },
+      warning = function(w) {
+        message("cmdstan already installed. Not reinstalling.")
+      }
+    )
+
+    if (!require(lilace)) {
+      stop("Lilace not available after renv restore. Check renv.lock and renv setup.")
+    }
+  }
+
+  marker <- file(output_file, open = "wt")
+  writeLines("Lilace installed.", marker)
+  close(marker)
+}
+
+tryCatch(
+  main(),
+  error = function(err) {
+    log_and_rethrow("install_lilace", err)
+  }
+)

--- a/workflow/rules/scripts/run_lilace.R
+++ b/workflow/rules/scripts/run_lilace.R
@@ -185,7 +185,7 @@ build_counts_for_replicate <- function(df_subset, experiment_name) {
   counts
 }
 
-run_lilace_for_condition <- function(experiment_definition, experiment_name, condition_name, noprocess) {
+run_lilace_for_condition <- function(experiment_definition, experiment_name, condition_name) {
   condition_df <- dplyr::filter(experiment_definition, .data$condition == condition_name)
   replicate_frames <- list()
 
@@ -199,10 +199,6 @@ run_lilace_for_condition <- function(experiment_definition, experiment_name, con
     counts <- annotate_variants(counts)
     c_cols <- grep("^c_", colnames(counts), value = TRUE)
     counts[c_cols] <- lapply(counts[c_cols], function(x) ifelse(is.na(x), 0L, as.integer(x)))
-
-    if (noprocess) {
-      counts$type <- ifelse(counts$variant == "_wt", "synonymous", "missense")
-    }
 
     counts$rep <- as.character(expt_replicate)
     replicate_frames[[as.character(expt_replicate)]] <- counts
@@ -234,7 +230,6 @@ run_lilace_for_condition <- function(experiment_definition, experiment_name, con
     lilace_obj,
     output_dir = output_dir,
     control_label = "synonymous",
-    use_positions = !noprocess,
     pseudocount = TRUE,
     n_parallel_chains = snakemake@threads
   )
@@ -249,6 +244,20 @@ main <- function() {
   baseline_condition <- snakemake@config[["baseline_condition"]]
   noprocess <- snakemake@config[["noprocess"]]
 
+  # Backstop: common.smk's validate_scoring_backend_mode rejects this
+  # combination at parse time, but guard here too in case the script is
+  # invoked outside the Snakefile (manual reruns, direct script execution).
+  # Lilace's Stan model requires a synonymous control set and has no
+  # total-counts fallback (see pimentellab/lilace R/input.R:39-45).
+  if (isTRUE(noprocess)) {
+    stop(paste(
+      "scoring_backend='lilace' is incompatible with noprocess=true.",
+      "Lilace requires a synonymous-variant control set and has no",
+      "total-counts fallback. Use scoring_backend='rosace' for noprocess",
+      "runs, or set noprocess=false."
+    ))
+  }
+
   lilace_dir <- file.path("results", experiment_name, "lilace")
   dir.create(lilace_dir, recursive = TRUE, showWarnings = FALSE)
 
@@ -258,7 +267,7 @@ main <- function() {
 
   for (condition_name in conditions) {
     message(sprintf("Running Lilace for condition: %s", condition_name))
-    run_lilace_for_condition(experiment_definition, experiment_name, condition_name, noprocess)
+    run_lilace_for_condition(experiment_definition, experiment_name, condition_name)
   }
 }
 

--- a/workflow/rules/scripts/run_lilace.R
+++ b/workflow/rules/scripts/run_lilace.R
@@ -152,6 +152,12 @@ build_counts_for_replicate <- function(df_subset, experiment_name) {
       file_name <- file.path(
         "results", experiment_name, "processed_counts", "enrich_format", paste0(sample_name, ".tsv")
       )
+      if (!file.exists(file_name)) {
+        stop(sprintf(
+          "Expected per-sample count file is missing: %s. Did upstream GATK / process_counts fail for sample '%s'?",
+          file_name, sample_name
+        ))
+      }
       this_count <- readr::read_tsv(file_name, show_col_types = FALSE)
 
       if (anyDuplicated(this_count$hgvs) > 0) {
@@ -223,6 +229,7 @@ run_lilace_for_condition <- function(experiment_definition, experiment_name, con
   )
 
   output_dir <- file.path("results", experiment_name, "lilace", condition_name)
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
   lilace_obj <- lilace::lilace_fit_model(
     lilace_obj,
     output_dir = output_dir,

--- a/workflow/rules/scripts/run_lilace.R
+++ b/workflow/rules/scripts/run_lilace.R
@@ -1,0 +1,280 @@
+#!/usr/bin/env Rscript
+
+init_logging <- function() {
+  log_file <- snakemake@log[[1]]
+  con <- file(log_file, open = "wt")
+  sink(con, append = FALSE, split = FALSE, type = "message")
+  sink(con, append = FALSE, split = FALSE, type = "output")
+  invisible(con)
+}
+
+stop_logging <- function(con) {
+  sink(type = "message")
+  sink(type = "output")
+  close(con)
+}
+
+log_and_rethrow <- function(script_name, err) {
+  message(sprintf("%s failed: %s", script_name, conditionMessage(err)))
+  calls <- vapply(
+    sys.calls(),
+    function(call) paste(deparse(call), collapse = " "),
+    character(1)
+  )
+  if (length(calls) > 0) {
+    message("Call stack:")
+    message(paste(calls, collapse = "\n"))
+  }
+  stop(err)
+}
+
+load_experiment_definition <- function(experiment_file) {
+  readr::read_csv(experiment_file, show_col_types = FALSE)
+}
+
+parse_stripped_hgvs <- function(hgvs_string) {
+  if (hgvs_string == "_wt") {
+    return(list(position = 0, wildtype = "", mutation = "WT", type = "synonymous"))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+=$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)=")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = match[2],
+      type = "synonymous"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+[A-Z]$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)([A-Z])")
+    mut_type <- ifelse(match[2] == match[4], "synonymous", "missense")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = match[4],
+      type = mut_type
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+\\*$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)\\*")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = "*",
+      type = "nonsense"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+_[A-Z][0-9]+del$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)_([A-Z])([0-9]+)del")
+    len <- as.integer(match[5]) - as.integer(match[3]) + 1
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = paste0("D_", len),
+      type = "deletion"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+del$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)del")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = "D_1",
+      type = "deletion"
+    ))
+  }
+
+  if (stringr::str_detect(hgvs_string, "^[A-Z][0-9]+_[A-Z][0-9]+ins[A-Z]+$")) {
+    match <- stringr::str_match(hgvs_string, "([A-Z])([0-9]+)_([A-Z])([0-9]+)ins([A-Z]+)")
+    return(list(
+      position = as.numeric(match[3]),
+      wildtype = match[2],
+      mutation = paste0("I_", nchar(match[6])),
+      type = "insertion"
+    ))
+  }
+
+  stop(sprintf("Unsupported HGVS format encountered: %s", hgvs_string))
+}
+
+annotate_variants <- function(counts) {
+  stripped <- counts$hgvs
+  stripped <- ifelse(stripped == "_wt", stripped, substr(stripped, 4, nchar(stripped) - 1))
+  parsed <- purrr::map(stripped, parse_stripped_hgvs)
+
+  counts %>%
+    dplyr::mutate(
+      variant = .data$hgvs,
+      position = purrr::map_dbl(parsed, "position"),
+      wildtype = purrr::map_chr(parsed, "wildtype"),
+      mutation = purrr::map_chr(parsed, "mutation"),
+      type = purrr::map_chr(parsed, "type")
+    ) %>%
+    dplyr::select(.data$variant, .data$type, .data$wildtype, .data$mutation, .data$position, dplyr::everything())
+}
+
+build_counts_for_replicate <- function(df_subset, experiment_name) {
+  counts <- tibble::tibble(hgvs = character())
+
+  for (expt_time in unique(df_subset$time)) {
+    experimental_time_df <- dplyr::filter(df_subset, .data$time == expt_time)
+    has_tile <- "tile" %in% colnames(experimental_time_df)
+    tile_values <- if (has_tile) unique(experimental_time_df$tile) else NA
+
+    time_count <- tibble::tibble(hgvs = character(), count = integer())
+
+    for (tile_val in tile_values) {
+      experimental_tile_df <- if (is.na(tile_val) || !has_tile) {
+        experimental_time_df
+      } else {
+        dplyr::filter(experimental_time_df, .data$tile == tile_val)
+      }
+
+      if (nrow(experimental_tile_df) > 1) {
+        stop(sprintf(
+          "More than one row in experiment definition for condition=%s replicate=%s tile=%s time=%s",
+          experimental_tile_df$condition[1],
+          experimental_tile_df$replicate[1],
+          tile_val,
+          expt_time
+        ))
+      }
+      if (nrow(experimental_tile_df) == 0) {
+        next
+      }
+
+      sample_name <- experimental_tile_df$sample[1]
+      file_name <- file.path(
+        "results", experiment_name, "processed_counts", "enrich_format", paste0(sample_name, ".tsv")
+      )
+      this_count <- readr::read_tsv(file_name, show_col_types = FALSE)
+
+      if (anyDuplicated(this_count$hgvs) > 0) {
+        stop(sprintf("Duplicate HGVS entries found in %s", file_name))
+      }
+
+      overlap <- intersect(time_count$hgvs, this_count$hgvs)
+      if (length(overlap) > 0) {
+        stop(sprintf(
+          "Overlapping HGVS variants across tiles at time %s: %s",
+          expt_time,
+          paste(head(overlap, 5), collapse = ", ")
+        ))
+      }
+      time_count <- dplyr::bind_rows(time_count, this_count)
+    }
+
+    if (nrow(time_count) > 0) {
+      col_name <- paste0("c_", expt_time)
+      counts <- dplyr::full_join(counts, time_count, by = "hgvs") %>%
+        dplyr::rename(!!col_name := .data$count)
+    }
+  }
+
+  counts
+}
+
+run_lilace_for_condition <- function(experiment_definition, experiment_name, condition_name, noprocess) {
+  condition_df <- dplyr::filter(experiment_definition, .data$condition == condition_name)
+  replicate_frames <- list()
+
+  for (expt_replicate in unique(condition_df$replicate)) {
+    replicate_df <- dplyr::filter(condition_df, .data$replicate == expt_replicate)
+    counts <- build_counts_for_replicate(replicate_df, experiment_name)
+    if (nrow(counts) == 0) {
+      next
+    }
+
+    counts <- annotate_variants(counts)
+    c_cols <- grep("^c_", colnames(counts), value = TRUE)
+    counts[c_cols] <- lapply(counts[c_cols], function(x) ifelse(is.na(x), 0L, as.integer(x)))
+
+    if (noprocess) {
+      counts$type <- ifelse(counts$variant == "_wt", "synonymous", "missense")
+    }
+
+    counts$rep <- as.character(expt_replicate)
+    replicate_frames[[as.character(expt_replicate)]] <- counts
+  }
+
+  if (length(replicate_frames) == 0) {
+    warning(sprintf("No valid counts found for condition %s", condition_name))
+    return(invisible(NULL))
+  }
+
+  model_df <- dplyr::bind_rows(replicate_frames) %>%
+    dplyr::filter(.data$variant != "_wt")
+
+  c_cols <- grep("^c_", colnames(model_df), value = TRUE)
+  c_cols <- c_cols[order(gsub("^c_", "", c_cols))]
+
+  lilace_obj <- lilace::lilace_from_counts(
+    variant_id = model_df$variant,
+    mutation_type = model_df$type,
+    position = model_df$position,
+    replicate = model_df$rep,
+    counts = as.matrix(model_df[, c_cols]),
+    metadata = model_df[, c("wildtype", "mutation")]
+  )
+
+  output_dir <- file.path("results", experiment_name, "lilace", condition_name)
+  lilace_obj <- lilace::lilace_fit_model(
+    lilace_obj,
+    output_dir = output_dir,
+    control_label = "synonymous",
+    use_positions = !noprocess,
+    pseudocount = TRUE,
+    n_parallel_chains = snakemake@threads
+  )
+
+  output_scores <- file.path("results", experiment_name, "lilace", paste0(condition_name, "_scores.csv"))
+  utils::write.csv(lilace_obj$scores, file = output_scores, row.names = FALSE)
+}
+
+main <- function() {
+  experiment_name <- snakemake@config[["experiment"]]
+  experiment_file <- snakemake@config[["experiment_file"]]
+  baseline_condition <- snakemake@config[["baseline_condition"]]
+  noprocess <- snakemake@config[["noprocess"]]
+
+  lilace_dir <- file.path("results", experiment_name, "lilace")
+  dir.create(lilace_dir, recursive = TRUE, showWarnings = FALSE)
+
+  experiment_definition <- load_experiment_definition(experiment_file)
+  conditions <- unique(experiment_definition$condition)
+  conditions <- conditions[conditions != baseline_condition]
+
+  for (condition_name in conditions) {
+    message(sprintf("Running Lilace for condition: %s", condition_name))
+    run_lilace_for_condition(experiment_definition, experiment_name, condition_name, noprocess)
+  }
+}
+
+con <- init_logging()
+on.exit({
+  stop_logging(con)
+}, add = TRUE)
+
+if (!snakemake@config[["lilace_local"]]) {
+  message("Activating renv environment")
+  renv::activate()
+}
+
+library("readr")
+library("stringr")
+library("dplyr")
+library("purrr")
+library("cmdstanr")
+library("lilace")
+
+tryCatch(
+  main(),
+  error = function(err) {
+    log_and_rethrow("run_lilace", err)
+  }
+)

--- a/workflow/rules/scripts/script_utils.py
+++ b/workflow/rules/scripts/script_utils.py
@@ -174,3 +174,23 @@ def validate_experiment_time_or_bin(experiments: pd.DataFrame) -> None:
         raise ValueError(
             "Invalid experiment definitions:\n  - " + details
         )
+
+
+def validate_scoring_backend_mode(config: dict) -> None:
+    """Reject incompatible combinations of scoring_backend and processing mode.
+
+    Lilace's Stan model structurally requires a synonymous-variant control set
+    (`R/input.R:39-45` in pimentellab/lilace raises if `control_label` matches
+    zero rows) and offers no total-counts fallback analogous to Rosace's
+    `normalization.method = "total"`. In noprocess mode the pipeline does not
+    parse HGVS into a trustworthy `synonymous` label, so the control set would
+    be empty and the run would fail deep inside R after a long install step.
+    Catch it here instead.
+    """
+    if config.get("noprocess") and config.get("scoring_backend") == "lilace":
+        raise ValueError(
+            "scoring_backend='lilace' is incompatible with noprocess=true. "
+            "Lilace requires a synonymous-variant control set and has no "
+            "total-counts fallback. Use scoring_backend='rosace' for "
+            "noprocess runs, or set noprocess=false."
+        )

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -61,6 +61,10 @@ properties:
     type: boolean
     default: false
     description: Flag for whether to use ROSACE installed on system-wide R or through a conda-controlled R environment.
+  lilace_local:
+    type: boolean
+    default: false
+    description: Flag for whether to use Lilace installed on system-wide R or through a conda-controlled R environment.
   bbtools_use_bgzip:
     type: boolean
     default: true

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -94,7 +94,7 @@ properties:
   enrich2:
     type: boolean
     default: false
-    description: Flag for whether to run Enrich2 in addition to Rosace.
+    description: Flag for whether to run Enrich2 in addition to the chosen scoring backend.
   remove_zeros:
     type: boolean
     default: false

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -50,6 +50,13 @@ properties:
     type: boolean
     default: false
     description: Flag for whether to use local samtools or wrapper version.
+  scoring_backend:
+    type: string
+    default: rosace
+    enum:
+      - rosace
+      - lilace
+    description: Scoring backend to run for variant effect inference.
   rosace_local:
     type: boolean
     default: false
@@ -80,6 +87,10 @@ properties:
     type: integer
     default: 16000
     description: memory for Rosace (in Mb)
+  mem_lilace:
+    type: integer
+    default: 16000
+    description: memory for Lilace (in Mb)
   enrich2:
     type: boolean
     default: false


### PR DESCRIPTION
provides a lilace option for dumpling, similarly to rosace, using "scoring_backend" configuration flag.

provides snakemake install and run rules similarly to rosace.

adds r test coverage for lilace.