### PR TITLE
Stream BBMap output to BAM instead of writing SAM intermediates

### DIFF
--- a/workflow/rules/asm.smk
+++ b/workflow/rules/asm.smk
@@ -4,7 +4,7 @@ rule gatk_ASM:
     input:
         index=str(reference_file) + ".fai",
         ref_dict=str(reference_file.parent / f"{reference_name}.dict"),
-        sam="results/{experiment}/{sample_prefix}.mapped.sam",
+        bam="results/{experiment}/{sample_prefix}.mapped.bam",
     output:
         "results/{experiment}/gatk/{sample_prefix}.variantCounts",
     params:
@@ -19,7 +19,7 @@ rule gatk_ASM:
     threads: 1
     shell:
         "gatk AnalyzeSaturationMutagenesis "
-        "-I {input.sam} "
+        "-I {input.bam} "
         "-R {params.ref} "
         "--orf {params.orf} "
         "--sequence-dictionary {input.ref_dict} "

--- a/workflow/rules/map.smk
+++ b/workflow/rules/map.smk
@@ -1,11 +1,13 @@
 rule map_to_reference_bbmap:
-    """Map reads to reference sequence using BBMap. covhist output is currently disabled as it causes MultiQC bloat."""
+    """Map reads to reference sequence using BBMap, streaming the SAM through
+    `samtools view -b` so the on-disk intermediate is a BAM. covhist output is
+    currently disabled as it causes MultiQC bloat."""
     input:
         index_dir=f"ref/bbmap/{experiment}_{ref_digest}",
         R1_ec="results/{experiment}/{sample_prefix}_R1.ec.clean.trim.fastq.gz",
         R2_ec="results/{experiment}/{sample_prefix}_R2.ec.clean.trim.fastq.gz",
     output:
-        mapped=temp("results/{experiment}/{sample_prefix}.mapped.sam"),
+        bam=temp("results/{experiment}/{sample_prefix}.mapped.bam"),
         covstats="stats/{experiment}/{sample_prefix}_map.covstats",
         basecov="stats/{experiment}/{sample_prefix}_map.basecov",
         bincov="stats/{experiment}/{sample_prefix}_map.bincov",
@@ -28,14 +30,14 @@ rule map_to_reference_bbmap:
         "|| (echo 'BBMap index missing summary file: {input.index_dir}/ref/genome/1/summary.txt' >&2; exit 1); "
         "[ -f {input.index_dir}/ref/genome/1/chr1.chrom.gz ] "
         "|| (echo 'BBMap index missing chrom file: {input.index_dir}/ref/genome/1/chr1.chrom.gz' >&2; exit 1); "
-        "bbmap.sh "
+        "( bbmap.sh "
         "-Xmx{params.mem}g "
         "in1={input.R1_ec} "
         "in2={input.R2_ec} "
         "sam={params.sam} 32bit=t "
         "path={input.index_dir} "
         "build=1 "
-        "outm={output.mapped} "
+        "outm=stdout.sam "
         "{params.compression_flags}"
         "k={params.kmers} "
         "t={threads} "
@@ -46,20 +48,6 @@ rule map_to_reference_bbmap:
         "ehist={output.ehist} "
         "indelhist={output.indelhist} "
         "mhist={output.mhist} "
-        "idhist={output.idhist} 2> {log}"
-
-
-rule sort_index_samtools:
-    """Sort and index mapped reads using samtools."""
-    input:
-        "results/{experiment}/{sample_prefix}.mapped.sam",
-    output:
-        bam=temp("results/{experiment}/{sample_prefix}.mapped.bam"),
-    benchmark:
-        "benchmarks/{experiment}/{sample_prefix}.samtools_sort.benchmark.txt"
-    log:
-        "logs/{experiment}/samtools/{sample_prefix}.samtools.log",
-    params:
-        extra="-O bam --write-index -o {output.bam}",
-    wrapper:
-        "v3.1.0/bio/samtools/sort"
+        "idhist={output.idhist} "
+        "| samtools view -b -o {output.bam} - "
+        ") 2> {log}"


### PR DESCRIPTION
BBMap previously wrote SAM to disk via outm=, the dead sort_index_samtools rule wrapped a samtools sort that nobody consumed, and GATK ASM read the plain-text SAM. None of the downstream tools care about sort order, so the sort was unused work and the SAM intermediate was paying ~3x the disk of the equivalent BAM.

Pipe BBMap's stdout through `samtools view -b` so the on-disk temp() is already a BAM; point GATK ASM at the BAM; delete the orphan sort rule. On example.yaml (14 samples, ~25-48MB input fastqs each):
  - gatk_ASM peak RSS: 1045MB -> 715MB (-32%)
  - gatk_ASM wall:     120s   -> 102s  (-15%)
  - mapped temp size:  ~150MB -> ~55MB per sample (~3x reduction)
  - bbmap_map wall:    +1.4s/job (samtools pipe overhead, acceptable)

Both runs produced 96/96 jobs, identical downstream rosace and enrich score outputs.