### PR TITLE
Stream GATK CSV reads instead of materializing the whole file

### DIFF
--- a/tests/integration/test_processing_pipeline.py
+++ b/tests/integration/test_processing_pipeline.py
@@ -22,11 +22,12 @@ class TestVariantProcessingChain:
         from process_variants import read_gatk_csv
 
         gatk_file = fixtures_dir / "mock_gatk_output.variantCounts"
-        result = read_gatk_csv(gatk_file)
+        # read_gatk_csv streams the file as a generator; materialize once for
+        # the row-level assertions below.
+        rows = list(read_gatk_csv(gatk_file))
 
-        assert isinstance(result, list), "Should return list of lists"
-        assert len(result) > 0, "Should have parsed rows"
-        assert all(len(row) == 9 for row in result), "All rows should have 9 columns"
+        assert len(rows) > 0, "Should have parsed rows"
+        assert all(len(row) == 9 for row in rows), "All rows should have 9 columns"
 
     def test_designed_variants_loading(self, fixtures_dir):
         """Test loading designed variants CSV."""

--- a/workflow/rules/scripts/process_variants.py
+++ b/workflow/rules/scripts/process_variants.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Any, Union
+from typing import Dict, Iterable, Iterator, List, Tuple, Any, Union
 import csv
 import pathlib
 import logging
@@ -54,26 +54,22 @@ def name_to_hgvs(name: str) -> str:
     return "p.(" + name + ")"
 
 
-def read_gatk_csv(file: Union[str, pathlib.Path]) -> GatkList:
+def read_gatk_csv(file: Union[str, pathlib.Path]) -> Iterator[List[str]]:
     # GATK output unfortunately may not be full-width, which will confuse pandas during
-    # reading in. We'll read each line and make sure it's full-length before passing it
-    # to pandas.
+    # reading in. Yield each line as a list, padded out to 9 columns. The caller
+    # iterates the generator exactly once (process_variants_file), so we never
+    # materialize the whole GATK output in memory — important on production
+    # samples where the file can be 100s of MB.
     logging.info("Loading GATK output file: %s", file)
-
-    gatk_list: GatkList = []
 
     p = pathlib.Path(file)
     p.parent.mkdir(parents=True, exist_ok=True)
 
     with p.open("r") as f:
-        lines = csv.reader(f, delimiter="\t")
-        for line in lines:
+        for line in csv.reader(f, delimiter="\t"):
             while len(line) < 9:
                 line = line + [""]
-
-            gatk_list.append(line)
-
-    return gatk_list
+            yield line
 
 
 # Process variant types
@@ -442,7 +438,7 @@ def update_stats(
 
 
 def process_variants_file(
-    gatk_list: GatkList,
+    gatk_list: Iterable[List[str]],
     designed_variants_df: pd.DataFrame,
     ref_AA_sequence: str,
     max_deletion_length: int,


### PR DESCRIPTION
read_gatk_csv previously loaded every line of the GATK variantCounts file into a list before returning. process_variants_file then iterated that list exactly once. On production samples (100s of MB per file, millions of rows) the materialization is unbounded memory for no benefit — the consumer can't seek backwards or peek ahead, it just streams forward.

Convert read_gatk_csv to a generator that yields padded rows one at a time and update process_variants_file's signature from GatkList (List[List[str]]) to Iterable[List[str]] so type annotations match the new contract. The generator owns the file handle for the duration of consumption — Python's `with` block stays open across yields and closes when the iterator is exhausted or GC'd.

Test impact:
  - tests/unit pass mock_gatk_list as plain Python lists; lists are iterables so process_variants_file still works unchanged.
  - tests/integration/test_processing_pipeline.py asserted isinstance(result, list) on the read_gatk_csv return; that was over-specification of the contract. Tightened to materialize the iterator into a list explicitly and assert on the row shape.

All 150 Python tests pass. Verified end-to-end on example.yaml: 81/81 jobs, 14 variantCounts + 14 per-sample enrich tsvs + both rosace condition scores produced through the streaming path.