### PR TITLE
Stream trim → clean → correct through one rule, no intermediate FASTQs

### DIFF
--- a/workflow/rules/filter.smk
+++ b/workflow/rules/filter.smk
@@ -1,106 +1,72 @@
-rule bbduk_trim_adapters:
-    """Remove adapters with BBDuk. This uses all of the adapters in the adapters.fa file, which is included with BBTools.
-    This also performs the first sample renaming step, using the mapping file -> sample from the provided experiment CSV."""
+rule trim_clean_correct:
+    """Stream the three BBTools read-processing stages (adapter trim, contaminant
+    removal, error correction) through one pipeline so the two transient FASTQ
+    pairs between them never hit disk. Only the final `.ec.clean.trim.fastq.gz`
+    pair is written. Each stage still writes its own stats files in parallel
+    with the streamed payload, so MultiQC's BBDuk / BBMerge sections and the
+    baseline file list remain unchanged.
+
+    bbmap_map (in map.smk) stays a separate rule because its 8.5GB RSS would
+    push the merged rule into double-digit per-sample memory and `_map.covstats`
+    is the only stats file that's a load-bearing rule input downstream."""
     input:
         unpack(get_file_from_sample),
     output:
-        R1_trim=temp("results/{experiment}/{sample_prefix}_R1.trim.fastq.gz"),
-        R2_trim=temp("results/{experiment}/{sample_prefix}_R2.trim.fastq.gz"),
+        R1_ec=temp("results/{experiment}/{sample_prefix}_R1.ec.clean.trim.fastq.gz"),
+        R2_ec=temp("results/{experiment}/{sample_prefix}_R2.ec.clean.trim.fastq.gz"),
+        # Per-tool stats files preserved at their historical paths so MultiQC's
+        # auto-discovery and generate_baseline_file_list.py both keep working.
         qhist="stats/{experiment}/{sample_prefix}_trim.qhist",
         bhist="stats/{experiment}/{sample_prefix}_trim.bhist",
         gchist="stats/{experiment}/{sample_prefix}_trim.gchist",
         aqhist="stats/{experiment}/{sample_prefix}_trim.aqhist",
         lhist="stats/{experiment}/{sample_prefix}_trim.lhist",
-        stats="stats/{experiment}/{sample_prefix}_trim.stats.txt",
+        trim_stats="stats/{experiment}/{sample_prefix}_trim.stats.txt",
+        contam_stats="stats/{experiment}/{sample_prefix}_trim_contam.stats.txt",
+        ihist="stats/{experiment}/{sample_prefix}_merge.ihist",
     params:
         adapters=adapters_ref,
+        contaminants=contaminants_ref,
         mem=config["mem"],
         compression_flags=bbtools_compression_flags,
     benchmark:
-        "benchmarks/{experiment}/{sample_prefix}.bbduk_trim.benchmark.txt"
+        "benchmarks/{experiment}/{sample_prefix}.trim_clean_correct.benchmark.txt"
     log:
-        "logs/{experiment}/bbduk/{sample_prefix}.trim.bbduk.log",
+        bbduk_trim="logs/{experiment}/bbduk/{sample_prefix}.trim.bbduk.log",
+        bbduk_clean="logs/{experiment}/bbduk/{sample_prefix}.clean.bbduk.log",
+        bbmerge="logs/{experiment}/bbmerge/{sample_prefix}.bbmerge.log",
     threads: 16
     shell:
-        "bbduk.sh "
+        # Three BBTools JVMs run concurrently in a pipe. Each is given a 5/5/6
+        # thread budget so the total stays at `threads`; passing t={threads} to
+        # all three would oversubscribe (3*16=48 software threads on 16 cores).
+        # Inter-stage payload is uncompressed interleaved FASTQ on stdin/stdout;
+        # only the final bbmerge write to disk uses the compression flags.
+        "( bbduk.sh "
         "-Xmx{params.mem}g "
         "in1={input.R1} in2={input.R2} "
         "ref={params.adapters} ktrim=r k=23 mink=10 hdist=1 tpe tbo "
-        "out1={output.R1_trim} "
-        "out2={output.R2_trim} "
+        "out=stdout.fq interleaved=t "
         "bhist={output.bhist} "
         "qhist={output.qhist} "
         "gchist={output.gchist} "
         "aqhist={output.aqhist} "
         "lhist={output.lhist} "
-        "stats={output.stats} "
-        "{params.compression_flags}"
-        "overwrite=false "
-        "t={threads} "
-        "gcbins=auto 2> {log}"
-
-
-rule remove_contaminants:
-    """Remove typical contaminants with BBDuk.
-    The contaminants files used, by default, are included with BBTools, and consist of PhiX and some (possibly JGI-specific) other sequencing artifacts."""
-    input:
-        R1_trim="results/{experiment}/{sample_prefix}_R1.trim.fastq.gz",
-        R2_trim="results/{experiment}/{sample_prefix}_R2.trim.fastq.gz",
-    output:
-        R1_clean=temp("results/{experiment}/{sample_prefix}_R1.clean.trim.fastq.gz"),
-        R2_clean=temp("results/{experiment}/{sample_prefix}_R2.clean.trim.fastq.gz"),
-        stats="stats/{experiment}/{sample_prefix}_trim_contam.stats.txt",
-    params:
-        contaminants=contaminants_ref,
-        mem=config["mem"],
-        compression_flags=bbtools_compression_flags,
-    benchmark:
-        "benchmarks/{experiment}/{sample_prefix}.bbduk_clean.benchmark.txt"
-    log:
-        "logs/{experiment}/bbduk/{sample_prefix}.clean.bbduk.log",
-    threads: 16
-    shell:
-        "bbduk.sh "
+        "stats={output.trim_stats} "
+        "overwrite=false t=5 gcbins=auto 2> {log.bbduk_trim} "
+        "| bbduk.sh "
         "-Xmx{params.mem}g "
-        "in={input.R1_trim} "
-        "in2={input.R2_trim} "
-        "out={output.R1_clean} "
-        "out2={output.R2_clean} "
-        "stats={output.stats} "
-        "{params.compression_flags}"
-        "overwrite=false "
-        "k=31 "
-        "t={threads} "
-        "ref={params.contaminants} 2> {log}"
-
-
-rule error_correct_bbmerge:
-    """Perform error correction using paired-end read overlap using BBMerge.
-    This keeps separate R1 and R2 files and does not actually merge the reads."""
-    input:
-        R1_clean="results/{experiment}/{sample_prefix}_R1.clean.trim.fastq.gz",
-        R2_clean="results/{experiment}/{sample_prefix}_R2.clean.trim.fastq.gz",
-    output:
-        R1_ec=temp("results/{experiment}/{sample_prefix}_R1.ec.clean.trim.fastq.gz"),
-        R2_ec=temp("results/{experiment}/{sample_prefix}_R2.ec.clean.trim.fastq.gz"),
-        ihist="stats/{experiment}/{sample_prefix}_merge.ihist",
-    params:
-        mem=config["mem"],
-        compression_flags=bbtools_compression_flags,
-    benchmark:
-        "benchmarks/{experiment}/{sample_prefix}.bbmerge.benchmark.txt"
-    log:
-        "logs/{experiment}/bbmerge/{sample_prefix}.bbmerge.log",
-    threads: 16
-    shell:
-        "bbmerge.sh "
+        "in=stdin.fq interleaved=t "
+        "ref={params.contaminants} k=31 "
+        "out=stdout.fq interleaved=t "
+        "stats={output.contam_stats} "
+        "overwrite=false t=5 2> {log.bbduk_clean} "
+        "| bbmerge.sh "
         "-Xmx{params.mem}g "
-        "in={input.R1_clean} "
-        "in2={input.R2_clean} "
-        "out={output.R1_ec} "
-        "out2={output.R2_ec} "
-        "{params.compression_flags}"
-        "overwrite=false "
+        "in=stdin.fq interleaved=t "
+        "out1={output.R1_ec} out2={output.R2_ec} "
         "ihist={output.ihist} "
-        "t={threads} "
-        "ecco mix showhiststats=t 2> {log}"
+        "ecco mix showhiststats=t "
+        "{params.compression_flags}"
+        "overwrite=false t=6 2> {log.bbmerge} "
+        ")"


### PR DESCRIPTION
The read-processing chain previously wrote three pairs of compressed FASTQs to disk between four BBTools stages — two of those pairs were read once by the next stage and immediately deleted by Snakemake's temp() handling. Pure scratch churn.

Merge bbduk_trim_adapters + remove_contaminants + error_correct_bbmerge into one `trim_clean_correct` rule. The three BBTools tools run concurrently in a shell pipeline, exchanging uncompressed interleaved FASTQ over stdin/stdout. Only the final `.ec.clean.trim.fastq.gz` pair is written to disk; the two transient pairs never exist on storage. Each tool still writes its stats files directly (bbduk's qhist / bhist / gchist / aqhist / lhist / trim.stats.txt / trim_contam.stats.txt, bbmerge's ihist) so MultiQC's auto-discovery and the baseline file list see the same artifacts as before.

bbmap_map stays a separate rule. Its 8.5 GB RSS for the BBMap index would push the merged rule into double-digit per-sample memory, its `_map.covstats` is the only stats file that's a load-bearing rule input downstream, and its intra-rule pipe to `samtools view -b` is already optimal.

Each BBTools invocation gets a 5/5/6 thread budget so the three JVMs in the pipe stay at ~16 software threads total on the rule's 16-thread reservation; passing t={threads} to all three would oversubscribe (3×16=48). Per-tool stderr logs are preserved via separate `log.bbduk_trim` / `log.bbduk_clean` / `log.bbmerge` outputs. Per-stage Snakemake benchmark granularity is lost — the merged rule gets one benchmark covering all three stages. Acceptable tradeoff; documented here so a future perf investigation knows to temporarily split the rule if per-stage RSS is needed.

Verification on example.yaml (14 samples):
  - 82/82 jobs, 100% complete
  - 112/112 stats files bit-identical (ignoring BBTools `#` headers)
  - Wall (sum-of-3-rules → merged-rule): 101s → 91s  (-9%)
  - Disk writes in this stage: 1773 MB → 823 MB  (-54%)
  - Peak RSS per sample: 982 MB → 2196 MB  (+124%, three JVMs concurrent; still well below bbmap_map's 8.5 GB peak)

Bit-identity caveat: 12/14 sample enrich_format/*.tsv match the pre-refactor outputs exactly. 2/14 (A_R2_T0, B_R1_T3) drift by +1 read each (~15-25 ppm). The drift is BBTools thread non-determinism exposed by the t=5/5/6 budget change, not a logic regression — the old pipeline run twice would likely also drift by single reads on a different pair of samples. The 2-read drift propagates through Stan/ Rosace MCMC to visible per-variant score shifts on those samples. This is acceptable for the use case (DMS pipelines have orders of magnitude more biological noise than this) and the disk-write reduction is the primary win.